### PR TITLE
Fix #1: If secret is not set, output was missing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
       env:
         SECRET: ${{ inputs.secret }}
       with:
-        github-token: ${{ inputs.secret }}
+        github-token: ${{ inputs.secret != '' && inputs.secret || github.token }}
         script: |
           if (process.env.CAN_SKIP_CHECKS == "false") {
             console.log("Setting CAN_SKIP_CHECKS to false");

--- a/action.yml
+++ b/action.yml
@@ -123,6 +123,8 @@ runs:
     - name: Compute/publish skip result
       id: passed-checks
       uses: actions/github-script@v7
+      env:
+        SECRET: ${{ inputs.secret }}
       with:
         github-token: ${{ inputs.secret }}
         script: |
@@ -132,7 +134,7 @@ runs:
             return;
           }
 
-          const secretProvided = '${{ inputs.secret }}' !== '';
+          const secretProvided = !!process.env.SECRET;
           if (!secretProvided) {
             console.log("secret input not set, assuming all checks have passed. Ensure 'Require status checks to pass before merging' is enabled, or provide a secret with administration:read.");
             core.setOutput("can-skip-checks", true);

--- a/action.yml
+++ b/action.yml
@@ -120,21 +120,7 @@ runs:
           echo "CAN_SKIP_CHECKS=false" >> "$GITHUB_ENV"
         fi
 
-    - name: Finalize result without verifying that required checks have passed (only if no secret is configured)
-      if: inputs.secret == ''
-      uses: actions/github-script@v7
-      with:
-        script: |
-          if (process.env.CAN_SKIP_CHECKS == "false") {
-            console.log("Setting CAN_SKIP_CHECKS to false");
-            core.setOutput("can-skip-checks", false);
-          } else {
-            console.log("secret input not set, assuming all checks have passed. Please make sure the setting 'Require status checks to pass before merging' is enabled in your repository. Alternatively, please configure the secret.");
-            core.setOutput("can-skip-checks", true);
-          }
-
-    - name: Check if PR branch already passed required checks
-      if: inputs.secret != ''
+    - name: Compute/publish skip result
       id: passed-checks
       uses: actions/github-script@v7
       with:
@@ -143,6 +129,13 @@ runs:
           if (process.env.CAN_SKIP_CHECKS == "false") {
             console.log("Setting CAN_SKIP_CHECKS to false");
             core.setOutput("can-skip-checks", false);
+            return;
+          }
+
+          const secretProvided = '${{ inputs.secret }}' !== '';
+          if (!secretProvided) {
+            console.log("secret input not set, assuming all checks have passed. Ensure 'Require status checks to pass before merging' is enabled, or provide a secret with administration:read.");
+            core.setOutput("can-skip-checks", true);
             return;
           }
 


### PR DESCRIPTION
This PR fixes #1.

### Problem

The action defined an output:

```yaml
outputs:
  skip-check:
    description: "Skip Check (boolean)"
    value: ${{ steps.passed-checks.outputs.can-skip-checks }}
```

but the step `passed-checks` only ran when `inputs.secret != ''`.
When no secret was provided, a different step ran without an `id`, so the `skip-check` output was never set. This broke the action when a secret was not configured.

### Fix

* Merged the two mutually exclusive steps (`Finalize result without verifying…` and `Check if PR branch already passed required checks`) into a **single `passed-checks` step**.
* That step always runs and always sets the `can-skip-checks` output.
* That step now checks whether a secret was provided
* If no secret is provided, the script assumes required checks have passed (as documented). If a secret is provided, it verifies required checks before setting the output.

### Result

The action now consistently produces the `skip-check` output in all cases. Consumers of the action can reliably use `${{ steps.this-action.outputs.skip-check }}` regardless of whether `inputs.secret` is set.